### PR TITLE
Workflow to build and upload pip wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release on PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-wheel:
+    name: "Build wheel"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - run: python -m pip install build
+      - run: python -m build --wheel
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist
+
+  release:
+    needs: "build-wheel"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - uses: actions/download-artifact@v3
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: |
+          github.repository == 'perrin-isir/xpag'
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![alt text](logo.png "logo")
+# ![alt text](https://github.com/perrin-isir/xpag/blob/main/logo.png "logo")
 
 ![version](https://img.shields.io/badge/version-0.1.0-blue)
 [![codestyle](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,18 @@ from setuptools import setup, find_packages
 
 # Install with 'pip install -e .'
 
+from pathlib import Path
+
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
+
 setup(
     name="xpag",
     version="0.1.0",
     author="Nicolas Perrin-Gilbert",
     description="xpag: Exploring Agents",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     url="https://github.com/perrin-isir/xpag",
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
Hello @perrin-isir, thanks for this nice repository. Following our discussions, this PR proposes an automatic way to build and upload wheels for xpag to PyPI. This will make it easier for other packages hosted on PyPI to depend on xpag. 

The release workflow won't change anything for regular push/PR and will only be activated if you push a tag by doing
```
git push origin vX.X.X
```
Then, the workflow tries to build the pip wheel and upload it to PyPi if successful. I had a try on the [test pypi mirror](https://test.pypi.org/project/xpag/), and it worked very well. Now you can do:
```
pip install --extra-index-url https://test.pypi.org/simple/ xpag
```
Notice: here we have to specify the test.pypi mirror bc it is not the default one. This temporary test upload will be removed after some time. 

After merging this PR, you can upload new wheels to (default) PyPi by pushing a new tag to your repo. The wheel for one specific version, for example your beta version 0.1.0, can only be pushed once to PyPi. Then you have to increase the version number to "update" the wheel.